### PR TITLE
Allow our URL to contains query parameters

### DIFF
--- a/src/de/tavendo/autobahn/WebSocketWriter.java
+++ b/src/de/tavendo/autobahn/WebSocketWriter.java
@@ -140,6 +140,10 @@ public class WebSocketWriter extends Thread {
 		if (path == null || path.length() == 0) {
 			path = "/";
 		}
+		String query = message.getURI().getQuery();
+		if (query != null && query.length() > 0) {
+			path = path + "?" + query;
+		}
 
 		mApplicationBuffer.put(("GET " + path + " HTTP/1.1" + CRLF).getBytes());
 		mApplicationBuffer.put(("Host: " + message.getURI().getHost() + CRLF).getBytes());


### PR DESCRIPTION
By using message.getURI().getPath() we retrieve only the path without any query. In the current library these query parameters are just ignored.
This commit fix the problem and add the query after the path
